### PR TITLE
Always performing upcase of a token secret

### DIFF
--- a/src/Gamgee/Effects/Crypto.hs
+++ b/src/Gamgee/Effects/Crypto.hs
@@ -62,14 +62,14 @@ encryptSecret spec =
       -- Ask the user for a password
       password <- SI.secretInput "Password to encrypt (leave blank to skip encryption): "
 
-      if Text.null password
-      then return spec
-      else do
-        -- Sometimes the secret may contain extraneous chars - '=', '-', space etc. Clear those.
-        let secret = (Text.toUpper . Text.dropWhileEnd (== '=') . Text.replace " " "" . Text.replace "-" "" . Text.strip) plainSecret
+      -- Sometimes the secret may contain extraneous chars - '=', '-', space etc. Clear those.
+      let secret = (Text.toUpper . Text.dropWhileEnd (== '=') . Text.replace " " "" . Text.replace "-" "" . Text.strip) plainSecret
 
-        secret' <- encrypt secret password
-        return spec { Token.tokenSecret = secret' }
+      secret' <- if Text.null password
+                 then pure $ Token.TokenSecretPlainText secret
+                 else encrypt secret password
+
+      return spec { Token.tokenSecret = secret' }
 
 decryptSecret :: Members [SI.SecretInput Text, Crypto] r
               => Token.TokenSpec

--- a/src/Gamgee/Operation.hs
+++ b/src/Gamgee/Operation.hs
@@ -99,5 +99,5 @@ changePassword ident = do
     Nothing   -> P.throw $ Eff.NoSuchToken ident
     Just spec -> do
       secret <- Eff.getSecret spec
-      spec' <- Eff.encryptSecret spec{ Token.tokenSecret = Token.TokenSecretPlainText secret }
+      spec' <- Eff.encryptSecret spec { Token.tokenSecret = Token.TokenSecretPlainText secret }
       P.put $ Map.insert ident spec' tokens


### PR DESCRIPTION
In plain text mode, `gamgee` wasn't performing an upcase operation on a secret, which lead to failures during Base32 decoding after reading from json store.