### PR TITLE
Wayland support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-.stack-work/
 *~
+*.swp
+dist-*
+dist
+.ghc.environment.*
+.stack-work/
+cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+source-repository-package
+  type: git
+  location: https://github.com/jetho/Hclip.git
+  tag: 16795d473acb33dfb8d425ba22ad1016d3440044
+
+packages: .

--- a/gamgee.cabal
+++ b/gamgee.cabal
@@ -42,7 +42,7 @@ library
   ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
       aeson ==1.5.6.0
-    , base ==4.14.1.0
+    , base >=4.13 && < 5
     , base64-bytestring ==1.1.0.0
     , bytestring ==0.10.12.0
     , cryptonite ==0.27
@@ -65,9 +65,9 @@ executable gamgee
   default-extensions: ApplicativeDo BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies EmptyCase ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      Hclip ==3.0.0.4
+      Hclip
     , aeson ==1.5.6.0
-    , base ==4.14.1.0
+    , base >=4.13 && < 5
     , directory ==1.3.6.0
     , filepath ==1.4.2.1
     , gamgee
@@ -96,7 +96,7 @@ test-suite gamgee-test
   build-depends:
       QuickCheck ==2.14.2
     , aeson ==1.5.6.0
-    , base ==4.14.1.0
+    , base >=4.13 && < 5
     , bytestring ==0.10.12.0
     , cryptonite ==0.27
     , filepath ==1.4.2.1


### PR DESCRIPTION
  Hclip recently merged wayland support. Use the upstream git version
  to be able to use that, since there has not been a new Hackage release
  by Hclip.
    
  While at it, update the bounds for base package.
