### PR TITLE
make it build with nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .stack-work/
 *~
+/result
+/dist-newstyle

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1696983906,
+        "narHash": "sha256-L7GyeErguS7Pg4h8nK0wGlcUTbfUMDu+HMf1UcyP72k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bd1cde45c77891214131cbbea5b1203e485a9d51",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "A command-line replacement for the Google Authenticator App";
+  inputs.nixpkgs.url = "nixpkgs";
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+        overlays = [ self.overlay ];
+      });
+    in
+    {
+      overlay = (final: prev: {
+        gamgee = final.haskellPackages.callCabal2nix "gamgee" ./. { };
+      });
+      packages = forAllSystems (system: {
+        gamgee = nixpkgsFor.${system}.gamgee;
+      });
+      defaultPackage = forAllSystems (system: self.packages.${system}.gamgee);
+      checks = self.packages;
+      devShell = forAllSystems (system:
+        let haskellPackages = nixpkgsFor.${system}.haskellPackages;
+        in haskellPackages.shellFor {
+          packages = p: [ self.packages.${system}.gamgee ];
+          withHoogle = true;
+          buildInputs = with haskellPackages; [
+            haskell-language-server
+            ghcid
+            cabal-install
+          ];
+          # Change the prompt to show that you are in a devShell
+          shellHook = "export PS1='\\e[1;34mdev > \\e[0m'";
+        });
+    };
+}

--- a/gamgee.cabal
+++ b/gamgee.cabal
@@ -41,17 +41,17 @@ library
   default-extensions: ApplicativeDo BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies EmptyCase ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
-      aeson ==1.5.6.0
-    , base ==4.14.1.0
-    , base64-bytestring ==1.1.0.0
-    , bytestring ==0.10.12.0
-    , cryptonite ==0.27
-    , memory ==0.15.0
-    , polysemy ==1.5.0.0
-    , relude ==0.7.0.0
-    , safe-exceptions ==0.1.7.1
-    , text ==1.2.4.1
-    , time ==1.9.3
+      aeson >=2
+    , base
+    , base64-bytestring
+    , bytestring
+    , cryptonite
+    , memory
+    , polysemy
+    , relude
+    , safe-exceptions
+    , text
+    , time
   default-language: Haskell2010
 
 executable gamgee
@@ -65,19 +65,19 @@ executable gamgee
   default-extensions: ApplicativeDo BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies EmptyCase ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      Hclip ==3.0.0.4
-    , aeson ==1.5.6.0
-    , base ==4.14.1.0
-    , directory ==1.3.6.0
-    , filepath ==1.4.2.1
+      Hclip
+    , aeson >=2
+    , base
+    , directory
+    , filepath
     , gamgee
-    , optparse-applicative ==0.15.1.0
-    , polysemy ==1.5.0.0
-    , relude ==0.7.0.0
-    , safe-exceptions ==0.1.7.1
-    , text ==1.2.4.1
-    , time ==1.9.3
-    , unix ==2.7.2.2
+    , optparse-applicative
+    , polysemy
+    , relude
+    , safe-exceptions
+    , text
+    , time
+    , unix
   default-language: Haskell2010
 
 test-suite gamgee-test
@@ -94,20 +94,20 @@ test-suite gamgee-test
   default-extensions: ApplicativeDo BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies EmptyCase ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck ==2.14.2
-    , aeson ==1.5.6.0
-    , base ==4.14.1.0
-    , bytestring ==0.10.12.0
-    , cryptonite ==0.27
-    , filepath ==1.4.2.1
+      QuickCheck
+    , aeson >=2
+    , base
+    , bytestring
+    , cryptonite
+    , filepath
     , gamgee
-    , memory ==0.15.0
-    , polysemy ==1.5.0.0
-    , quickcheck-instances ==0.3.25.2
-    , relude ==0.7.0.0
-    , tasty ==1.2.3
-    , tasty-golden ==2.3.3.2
-    , tasty-quickcheck ==0.10.1.2
-    , text ==1.2.4.1
-    , time ==1.9.3
+    , memory
+    , polysemy
+    , quickcheck-instances
+    , relude
+    , tasty
+    , tasty-golden
+    , tasty-quickcheck
+    , text
+    , time
   default-language: Haskell2010


### PR DESCRIPTION
Version constrains of dependencies in gamgee.cabal are too strict. I managed to build the project easily with recent nix after removing the constrains:
```console
$ nix build github:alexoundos/gamgee
```
or inside the git workdir:
```console
$ nix build
```

Don't know about stack, haven't updated its yaml file to newer LTS.